### PR TITLE
Fix GitHub Actions CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,20 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ^1.13
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2.5.2
+      uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.41
+        version: v1.46.2
 
     - name: Get dependencies
       run: |

--- a/docker.go
+++ b/docker.go
@@ -26,7 +26,6 @@ import (
 	"io"
 
 	dockerTypes "github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	dockerClient "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 )
@@ -40,14 +39,14 @@ func getDockerClient() (*dockerClient.Client, error) {
 	return dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
 }
 
-func imagePush(dockerClient *client.Client, authConfig dockerTypes.AuthConfig, repo string, tag string) (ImageId, error) {
+func imagePush(client *dockerClient.Client, authConfig dockerTypes.AuthConfig, repo string, tag string) (ImageId, error) {
 
 	authConfigBytes, _ := json.Marshal(authConfig)
 	authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 
 	target := repo + ":" + tag
 	opts := dockerTypes.ImagePushOptions{RegistryAuth: authConfigEncoded}
-	rd, err := dockerClient.ImagePush(context.Background(), target, opts)
+	rd, err := client.ImagePush(context.Background(), target, opts)
 	if err != nil {
 		return ImageId{}, err
 	}
@@ -62,9 +61,9 @@ func imagePush(dockerClient *client.Client, authConfig dockerTypes.AuthConfig, r
 	return getImageIdFromDockerDaemonJsonMessages(*buf)
 }
 
-func imageTag(dockerClient *client.Client, imageId string, newImageId string) error {
+func imageTag(client *dockerClient.Client, imageId string, newImageId string) error {
 
-	err := dockerClient.ImageTag(context.Background(), imageId, newImageId)
+	err := client.ImageTag(context.Background(), imageId, newImageId)
 	if err != nil {
 		return err
 	}

--- a/scripts/run-linter.sh
+++ b/scripts/run-linter.sh
@@ -4,4 +4,4 @@ set -ex
 
 TOP="$(git rev-parse --show-toplevel)"
 
-docker run --rm -v "${TOP}:/app" -w /app golangci/golangci-lint:v1.41.0 golangci-lint run -v
+docker run --rm -v "${TOP}:/app" -w /app golangci/golangci-lint:v1.46.2 golangci-lint run -v


### PR DESCRIPTION
This PR updates the version of `golangci-lint` as well as versions of Github Actions used in CI jobs. 
It fixes the CI failures and makes all checks passed.

Before:
- https://github.com/fivexl/aws-ecr-client-golang/actions/runs/2636174864
- https://github.com/fivexl/aws-ecr-client-golang/actions/runs/2636196554

After:
- https://github.com/fivexl/aws-ecr-client-golang/runs/7272221136