### PR TITLE
Handle full image references with new "--images" argument 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # build artifacts
 build/
 release/
+aws-ecr-client-golang

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ GLOBAL OPTIONS:
    --junit-report-path value, -j value  If set then CVE scan result will be written in JUNIT format to the path provided as a value. Useful for CI (like Jenkins) to keep ignored CVE visible [$AWS_ECR_CLIENT_JUNIT_REPORT_PATH]
    --scan-wait-timeout value            The max duration (in minutes) to wait for the image scan to complete. If exceeded, the operation will fail and the tag will not be pushed. (default: 20) [$AWS_ECR_CLIENT_SCAN_WAIT_TIMEOUT]
    --skip-push, -p                      Only push to scanning silo and do not push to destination repo even if there are no CVE's (useful for CI). (default: false) [$AWS_ECR_CLIENT_SKIP_PUSH]
-   --stage-repo value, -s value         Repository where image will be sent for scanning before pushing it to destination repo with the tag <destination-repo-name>-<tag>-scan-<timestamp>. Will push directly to destination repo with the specified tag if no value provided (default: empty string) [$AWS_ECR_CLIENT_STAGE_REPO]
-
+   --stage-ecr-repo value, -s value     AWS ECR Repository where the image will be sent for scanning before pushing it to destination repo with the tag ecs-client-scan-<timestamp>. If omitted, then the repo of the first wiven image will be used. (default: empty string) [$AWS_ECR_CLIENT_STAGE_ECR_REPO]
 
   Find source code, usage examples, report issues, get support: https://github.com/fivexl/aws-ecr-client-golang
 ```

--- a/commands.go
+++ b/commands.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 package main
 
-func Push(destinationRepo string, tag string) (ImageId, error) {
+func Push(imageRef string) (ImageId, error) {
 	client, err := GetECRClient()
 	if err != nil {
 		return ImageId{}, err
@@ -34,7 +34,7 @@ func Push(destinationRepo string, tag string) (ImageId, error) {
 		return ImageId{}, err
 	}
 
-	return imagePush(cli, authConfig, destinationRepo, tag)
+	return imagePush(cli, authConfig, imageRef)
 }
 
 func Tag(imageId string, newImageId string) error {

--- a/docker.go
+++ b/docker.go
@@ -39,14 +39,13 @@ func getDockerClient() (*dockerClient.Client, error) {
 	return dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
 }
 
-func imagePush(client *dockerClient.Client, authConfig dockerTypes.AuthConfig, repo string, tag string) (ImageId, error) {
+func imagePush(client *dockerClient.Client, authConfig dockerTypes.AuthConfig, imageRef string) (ImageId, error) {
 
 	authConfigBytes, _ := json.Marshal(authConfig)
 	authConfigEncoded := base64.URLEncoding.EncodeToString(authConfigBytes)
 
-	target := repo + ":" + tag
 	opts := dockerTypes.ImagePushOptions{RegistryAuth: authConfigEncoded}
-	rd, err := client.ImagePush(context.Background(), target, opts)
+	rd, err := client.ImagePush(context.Background(), imageRef, opts)
 	if err != nil {
 		return ImageId{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.16.7
 	github.com/aws/aws-sdk-go-v2/config v1.15.13
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.17.8
+	github.com/distribution/distribution v2.8.1+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/distribution v2.8.1+incompatible h1:8iXUoOqRPx30bhzIEPUmNIqlmBlWdrieW1bqr6LrX30=
+github.com/distribution/distribution v2.8.1+incompatible/go.mod h1:EgLm2NgWtdKgzF9NpMzUKgzmR7AMmb0VQi2B+ZzDRjc=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=

--- a/main.go
+++ b/main.go
@@ -109,11 +109,7 @@ func main() {
 		},
 	}
 
-	cli.AppHelpTemplate = fmt.Sprintf(`%s
-
-	Find source code, usage examples, report issues, get support: https://github.com/fivexl/aws-ecr-client-golang
-
-	`, cli.AppHelpTemplate)
+	cli.AppHelpTemplate = fmt.Sprintf("%sFind source code, usage examples, report issues, get support: https://github.com/fivexl/aws-ecr-client-golang\n", cli.AppHelpTemplate)
 
 	app.Action = func(c *cli.Context) error {
 
@@ -213,5 +209,4 @@ func main() {
 		fmt.Printf("Error: %v", err)
 		os.Exit(1)
 	}
-	fmt.Println("Done")
 }

--- a/main.go
+++ b/main.go
@@ -54,12 +54,12 @@ func main() {
 				Required:    true,
 			},
 			&cli.StringFlag{
-				Name:        "stage-repo",
+				Name:        "stage-ecr-repo",
 				Aliases:     []string{"s"},
 				Value:       "",
 				DefaultText: "empty string",
-				Usage:       "Repository where image will be sent for scanning before pushing it to destination repo with the tag <destination-repo-name>-<tag>-scan-<timestamp>. Will push directly to destination repo with the specified tag if no value provided",
-				EnvVars:     []string{"AWS_ECR_CLIENT_STAGE_REPO"},
+				Usage:       "AWS ECR Repository where the image will be sent for scanning before pushing it to destination repo with the tag ecs-client-scan-<timestamp>. If omitted, then the repo of the first wiven image will be used.",
+				EnvVars:     []string{"AWS_ECR_CLIENT_STAGE_ECR_REPO"},
 				Destination: &stageRepo,
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
Closes #13 

IMPROVEMENTS:
- Add a new argument `--images`, which accepts a space-separated list of images should be passed in a fully-qualified format, e.q.  "<domain>/<path>:<tag>". 

BREAKING CHANGES:
- Removed the following arguments (and corresponding env vars), as replaced by `--images`:
  - `--destination-repo`
  - `--additional-tags`
  - `--tag`

- Renamed the argument `--stage-repo` to `--stage-ecr-repo` to highlight that it expects only AWS ECR repo.