### PR TITLE
Fix golangci-lint failure on Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.46.2
+        version: v1.48
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
Ref: https://github.com/golangci/golangci-lint-action/issues/545